### PR TITLE
fix: unintended disconnection & code cleanup

### DIFF
--- a/src/main/java/com/jaoafa/chatwatcher/event/AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/chatwatcher/event/AutoDisconnect.java
@@ -1,5 +1,7 @@
 package com.jaoafa.chatwatcher.event;
 
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
@@ -7,25 +9,30 @@ import org.jetbrains.annotations.NotNull;
 public class AutoDisconnect extends ListenerAdapter {
     @Override
     public void onGuildVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {
-        if (event.getChannelJoined() != null || event.getChannelLeft() == null) return; // 退出以外は除外
-        if (event.getGuild().getSelfMember().getVoiceState() == null ||
-                event.getGuild().getSelfMember().getVoiceState().getChannel() == null) {
-            return; // 自身がどのVCにも参加していない
-        }
-        if (event.getGuild().getSelfMember().getVoiceState().getChannel().getIdLong() != event.getChannelLeft().getIdLong()) {
-            return; // 退出されたチャンネルが自身のいるVCと異なる
-        }
+        if (event.getMember().getUser().isBot()) return;
 
-        // VCに残ったユーザーが全員Bot、または誰もいなくなった
-        boolean existsUser = event
-                .getChannelLeft()
+        AudioChannel oldChannel = event.getChannelLeft();
+        AudioChannel newChannel = event.getChannelJoined();
+
+        // 退出以外は除外
+        if (oldChannel == null || newChannel != null) return;
+
+        GuildVoiceState selfVoiceState = event.getGuild().getSelfMember().getVoiceState();
+
+        // 自身がどのVCにも参加していない
+        if (selfVoiceState == null || selfVoiceState.getChannel() == null) return;
+
+        // 退出されたチャンネルが自身のいるVCと異なる
+        if (selfVoiceState.getChannel().getIdLong() != oldChannel.getIdLong()) return;
+
+        // 現在のチャンネルにまだ人がいるかどうか
+        boolean userExists = oldChannel
                 .getMembers()
                 .stream()
                 .anyMatch(member -> !member.getUser().isBot()); // Bot以外がいるかどうか
 
-        if (existsUser) {
-            return;
-        }
+        if (userExists) return;
+
         event.getGuild().getAudioManager().closeAudioConnection();
     }
 }

--- a/src/main/java/com/jaoafa/chatwatcher/event/AutoJoin.java
+++ b/src/main/java/com/jaoafa/chatwatcher/event/AutoJoin.java
@@ -1,6 +1,7 @@
 package com.jaoafa.chatwatcher.event;
 
 import com.jaoafa.chatwatcher.lib.Utils;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
@@ -8,14 +9,16 @@ import org.jetbrains.annotations.NotNull;
 public class AutoJoin extends ListenerAdapter {
     @Override
     public void onGuildVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {
-        if (event.getChannelJoined() == null) return; // 参加と移動以外は除外
-        if (event.getMember().getUser().isBot()) {
-            return;
-        }
-        if (event.getGuild().getSelfMember().getVoiceState() != null &&
-                event.getGuild().getSelfMember().getVoiceState().getChannel() != null) {
-            return; // 自身がいずれかのVCに参加している
-        }
+        if (event.getMember().getUser().isBot()) return;
+
+        // 参加と移動以外は除外
+        if (event.getChannelJoined() == null) return;
+
+        GuildVoiceState selfVoiceState = event.getGuild().getSelfMember().getVoiceState();
+
+        // 自身がいずれかのVCに参加している
+        if (selfVoiceState != null && selfVoiceState.getChannel() != null) return;
+
         Utils.connectVoiceChannel(event.getGuild(), event.getChannelJoined());
     }
 }


### PR DESCRIPTION
https://github.com/jaoafa/JDA-VCSpeaker/pull/233 と大体同じです。

まだユーザがVCに滞在しているのに、AFKに移動したユーザーがいる場合、ChatWatcherが退出してしまう問題を解決しました。  
また、処理の順番の統一や、冗長なコードの整理を行いました。